### PR TITLE
Develop

### DIFF
--- a/assets/javascripts/redmine_editor_preview_tab.js
+++ b/assets/javascripts/redmine_editor_preview_tab.js
@@ -12,7 +12,6 @@ var RedmineWikiTabPreview = RedmineWikiTabPreview || {};
  */
 
 RedmineWikiTabPreview.Text = RedmineWikiTabPreview.Text || {
-  NO_PREVIEW: 'Nothing to preview',
   PREVIEW_DIVS: {
     description: 'Description',
     notes: 'Notes',
@@ -80,18 +79,13 @@ RedmineWikiTabPreview.PreviewHtml = (function(Text) {
   };
 
   var get = function() {
-    var $preview = previewHtmlEle($preview);
-    return $preview.html() || '';
+    return previewHtmlEle().html() || '';
   };
 
   // private
 
   var previewHtmlEle = function() {
-    var $form = $preview.closest('form');
-    if ($form.attr('id').match(/journal/)) {
-      return $form.find(selectorString());
-    }
-    return $('#preview ' + selectorString());
+    return $preview.find(selectorString());
   };
 
   var selectorString = function() {
@@ -121,13 +115,14 @@ RedmineWikiTabPreview.PreviewHtml = (function(Text) {
 RedmineWikiTabPreview.View = (function(PreviewHtml, Text) {
   var $preview;
 
-  var init = function(preview) {
+  var init = function(preview, original_preview) {
     $preview = preview;
+    $original_preview = original_preview;
     return this;
   };
 
   var update = function() {
-    var html = PreviewHtml.init($preview).get()
+    var html = PreviewHtml.init($original_preview).get()
       .replace(/<legend>[^>]*>/g, '').trim();
     if (html.length === 0) {
       html = Text.NO_PREVIEW;
@@ -170,12 +165,14 @@ RedmineWikiTabPreview.Ajax = (function(View) {
   // Overide main submitPreview method
   var submitPreview = function(url, form, target) {
     $.ajax({
-      url: url,
+      url: url + '&editor_preview_tab=1',
       type: 'post',
       data: $('#' + form).serialize(),
       success: function(data) {
-        $('#' + target).html(data);
-        View.init($preview).update();
+        var preview = $('<div />')
+          .data({type: $preview.data('type')})
+          .html(data);
+        View.init($preview, preview).update();
       }
     });
   };

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,4 @@
 # English strings go here for Rails i18n
 en:
-  label_no_preview: Nothing to preview
   label_write: Write
+  label_no_preview: Nothing to preview

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,4 @@
+# Brazilian Portuguese strings go here for Rails i18n
+en:
+  label_write: Escrever
+  label_no_preview: Nenhum conteúdo para pré-visualizar

--- a/init.rb
+++ b/init.rb
@@ -1,11 +1,12 @@
 # encoding: utf-8
 require_dependency 'redmine_editor_preview_tab'
+require_dependency 'redmine_editor_preview_tab/preview_controller_patch'
 
 Redmine::Plugin.register :redmine_editor_preview_tab do
   name 'Redmine Editor Preview Tab Extension'
   author 'Thomas Leishman'
   description 'The Redmine Editor Preview Tab Extension adds a preview tab to the Redmine text editor, similar to the editor on Github.'
-  version '0.1.1'
+  version '0.1.2'
   url 'https://github.com/tleish/redmine_editor_preview_tab'
   author_url 'https://github.com/tleish'
   settings :default => { hide_default_preview: false, enabled: true } , :partial => 'redmine_editor_preview_tab/settings'

--- a/lib/redmine_editor_preview_tab/preview_controller_patch.rb
+++ b/lib/redmine_editor_preview_tab/preview_controller_patch.rb
@@ -1,0 +1,21 @@
+# Patch to always show issue preview
+require 'previews_controller'
+
+module PreviewsControllerPatch
+  def issue
+    params[:issue][:description] << ' ' if description? && editor_preview_tab?
+    super
+  end
+
+  private
+
+  def editor_preview_tab?
+    params[:editor_preview_tab].present?
+  end
+
+  def description?
+    params.fetch(:issue, {})[:description].present?
+  end
+end
+
+PreviewsController.prepend(PreviewsControllerPatch)


### PR DESCRIPTION
#1 adding support for Brazilian Portuguese

Handle tab preview and original preview show div separately. Also ensure the issue description preview to always display when using the preview tab.
