### PR TITLE
Handle issue description focus after AJAX update

### DIFF
--- a/assets/javascripts/redmine_editor_preview_tab.js
+++ b/assets/javascripts/redmine_editor_preview_tab.js
@@ -265,6 +265,26 @@ RedmineWikiTabPreview.EditorEvents = (function(Elements, TabEvents) {
 })(RedmineWikiTabPreview.Elements, RedmineWikiTabPreview.TabEvents);
 
 /**
+ * @class EditorAutoFocus
+ * @desc Auto focus on editors when edit button is clicked
+ */
+RedmineWikiTabPreview.EditorAutoFocus = (function() {
+  var init = function() {
+    $(document).ajaxSuccess(function() {
+      $("#issue_description").focus();
+      var $editLink = $('#all_attributes .icon-edit').parent();
+      $editLink.on('click', function() {
+        $('#issue_description').focus();
+      });
+    });
+  };
+
+  return {
+    init: init
+  };
+})();
+
+/**
  * @class EnsureAjaxCsrf
  * @desc Ensure that CSRF token is include with Ajax calls
  */
@@ -329,6 +349,7 @@ $(function() {
 
     RedmineWikiTabPreview.EnsureAjaxCsrf.init();
     RedmineWikiTabPreview.EditorEvents.init();
+    RedmineWikiTabPreview.EditorAutoFocus.init();
   }
 
 });


### PR DESCRIPTION
This PR fixes a problem that Editor Preview tab is not displayed after some AJAX events.

### Case1

1. Open "New issue" page.
2. Change "Tracker".

### Case2

1. Click "Edit" on an issue page.
2. Change "Project", "Tracker" or "Status".
3. Click "Edit" of Description.
